### PR TITLE
[fix Disruptor leak threads]#1

### DIFF
--- a/reader/src/main/java/com/meituan/ptubes/reader/container/common/utils/AppUtil.java
+++ b/reader/src/main/java/com/meituan/ptubes/reader/container/common/utils/AppUtil.java
@@ -12,7 +12,7 @@ import org.apache.commons.lang3.StringUtils;
 public class AppUtil {
 
     private static final Logger LOG = LoggerFactory.getLogger(AppUtil.class);
-    private static final String VERSION = "1.5.0";
+    private static final String VERSION = "1.0.0";
 
     public static volatile String APP_NAME = null;
     public static String IP = IPUtil.getIpV4();


### PR DESCRIPTION
### What is the purpose of the change
fix issuse https://github.com/meituan/ptubes/issues/1

### Brief Changelog
The startup of BinlogPipeline is divided into two steps. The first step is to initialize some resources. Only after the database is successfully linked, will BinlogPipeline be started and the thread initialized to avoid thread leakage.

### Verify this change
- [x] Make sure there is a GitHub_issue field for changes (usually before you start working on it). Trivial changes like spelling mistakes do not require GitHub issues. Your pull request should only address this issue and no other changes - one PR addresses one issue.
- [x] Every commit in a pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write the necessary unit tests to verify your logic corrections, mocks work better when there are cross-module dependencies.
- [x] GitHub Actions works fine on your own fork.